### PR TITLE
Ajout correction

### DIFF
--- a/Boite_a_outils/CorrectionPageXMLeScriptorium/migrationCorrection.xsl
+++ b/Boite_a_outils/CorrectionPageXMLeScriptorium/migrationCorrection.xsl
@@ -30,6 +30,8 @@
             <xsl:copy-of select="pr:PrintSpace"/>
             <xsl:copy-of select="pr:ReadingOrder"/>
             <xsl:apply-templates select="pr:TextRegion"/>
+            <xsl:copy-of select="pr:GraphicRegion"/>
+            <xsl:copy-of select="pr:SeparatorRegion"/>
         </xsl:element>
     </xsl:template>
     

--- a/Boite_a_outils/CorrectionPageXMLeScriptorium/migrationCorrection.xsl
+++ b/Boite_a_outils/CorrectionPageXMLeScriptorium/migrationCorrection.xsl
@@ -65,6 +65,9 @@
             <xsl:copy-of select="pr:Coords"/>
             <xsl:copy-of select="pr:Baseline"/>
             <xsl:element name="Word">
+                <xsl:attribute name="id">
+                    <xsl:value-of select="pr:Word/@id"/>
+                </xsl:attribute>
                 <xsl:element name="Coords">
                     <xsl:attribute name="points">
                         <xsl:value-of select="pr:Coords/@points"/>


### PR DESCRIPTION
Ajout de deux  balises qui avaient été oubliées
Ajout d'un id pour la nouvelle balise <Word> : nous avons choisi de prendre l'id de la première balise <Word> de l'encodage original