### PR TITLE
Mise en forme des scripts de corrections et nettoyages des fichiers PageXML

### DIFF
--- a/Boite_a_outils/CorrectionPageXMLeScriptorium/automatic_correction.py
+++ b/Boite_a_outils/CorrectionPageXMLeScriptorium/automatic_correction.py
@@ -5,7 +5,18 @@ import re
 from lxml import etree as ET
 import errno
 
-def nettoyage_automatique(chemin, dossier_resultat):
+def transformation_automatique(chemin, dossier_resultat):
+    """
+    Fonction permettant, pour chaque fichier d'un dossier donné, de lui appliquer la feuille de transformation
+    migrationCorrection.xsl qui insère les éléments contenus dans //textLine//textEquiv dans //textLine//textWord//text
+    Equiv dans le but d'avoir une version corrigée des transcriptions affichée dans eScriptorium.
+    :param chemin: chaîne de caractères correspondant au chemin relatif du dossier contenant les fichiers à transformer
+    :type chemin: str
+    :param dossier_resultat:chaîne de caractères correspondant au chemin relatif du dossier devant contenir l'output
+    :type dossier_resultat: str
+    :return: fichier pageXML contenant une version corrigée de l'input
+    :return: file
+    """
     # si le dossier résultat n'existe pas, on le créé, sinon, on ne fait rien
     if not os.path.exists(os.path.dirname(dossier_resultat)):
         try:
@@ -26,4 +37,4 @@ def nettoyage_automatique(chemin, dossier_resultat):
 # récupérer le dossier à transformer et le dossier résultat
 chemin_input = input("entrez le chemin du dossier: ")
 chemin_output = input("entrez le chemin du dossier résultat: ")
-nettoyage_automatique(chemin_input, chemin_output)
+transformation_automatique(chemin_input, chemin_output)

--- a/Boite_a_outils/CorrectionPageXMLeScriptorium/automatic_correction.py
+++ b/Boite_a_outils/CorrectionPageXMLeScriptorium/automatic_correction.py
@@ -5,22 +5,25 @@ import re
 from lxml import etree as ET
 import errno
 
-#récupérer le dossier à transformer et le dossier résultat
-chemin = input("entrez le chemin du dossier: ")
-dossier_resultat = input("entrez le chemin du dossier résultat: ")
-# si le dossier résultat n'existe pas, on le créé, sinon, on ne fait rien
-if not os.path.exists(os.path.dirname(dossier_resultat)):
-    try:
-        os.makedirs(os.path.dirname(dossier_resultat))
-    except OSError as exc:  # Guard against race condition
-        if exc.errno != errno.EEXIST:
-            raise
+def nettoyage_automatique(chemin, dossier_resultat):
+    # si le dossier résultat n'existe pas, on le créé, sinon, on ne fait rien
+    if not os.path.exists(os.path.dirname(dossier_resultat)):
+        try:
+            os.makedirs(os.path.dirname(dossier_resultat))
+        except OSError as exc:  # Guard against race condition
+            if exc.errno != errno.EEXIST:
+                raise
 
-for fichier in os.listdir(chemin):
-    # pour chaque fichier du dossier, on applique la feuille de transformation de correction
-    original = ET.parse(chemin+fichier)
-    transformation_xlst = ET.XSLT(ET.parse("migrationCorrection.xsl"))
-    propre = transformation_xlst(original)
-    #on créé un nouveau fichier dans le dossier résultat
-    with open(dossier_resultat+fichier, mode='wb') as f:
-        f.write(propre)
+    for fichier in os.listdir(chemin):
+        # pour chaque fichier du dossier, on applique la feuille de transformation de correction
+        original = ET.parse(chemin+fichier)
+        transformation_xlst = ET.XSLT(ET.parse("migrationCorrection.xsl"))
+        propre = transformation_xlst(original)
+        #on créé un nouveau fichier dans le dossier résultat
+        with open(dossier_resultat+fichier, mode='wb') as f:
+            f.write(propre)
+
+# récupérer le dossier à transformer et le dossier résultat
+chemin_input = input("entrez le chemin du dossier: ")
+chemin_output = input("entrez le chemin du dossier résultat: ")
+nettoyage_automatique(chemin_input, chemin_output)

--- a/Boite_a_outils/suppressionGrasItalique.py
+++ b/Boite_a_outils/suppressionGrasItalique.py
@@ -1,0 +1,31 @@
+"""
+Script d'automatisation de la suppression des balises <b> et <i> des documents PageXML
+Auteur: Juliette Janes
+Date: 12/03/2021
+"""
+
+import os
+from lxml import etree as ET
+
+def nettoyage_automatique(chemin):
+    """
+    Fonction permettant, pour chaque fichier d'un dossier, de parser le document, le transformer en chaîne de
+    caractères, supprimer les balises <b> et <i> et réinsèrer la chaîne obtenue dans le fichier.
+    :param chemin: chaîne de caractère correspond au chemin relatif du dossier contenant les fichiers à transformer
+    :return: str
+    """
+
+    for fichier in os.listdir(chemin):
+        original = ET.parse(chemin + fichier)
+        original_chaine = ET.tostring(original, encoding="unicode")
+    nettoyage = original_chaine.replace('&lt;b&gt;', '').replace('&lt;/b&gt;', '').replace(
+        '&lt;i&gt;', '').replace('&lt;/i&gt;', '')
+
+        #on créé un nouveau fichier dans le dossier résultat
+        with open(chemin+fichier, mode='w') as f:
+            f.write(nettoyage)
+        print(fichier, "traité")
+
+# récupérer le dossier à transformer et le dossier résultat
+chemin_input = input("entrez le chemin du dossier: ")
+nettoyage_automatique(chemin_input)


### PR DESCRIPTION
- Nettoyage du script correction_automatique pour récupérer un fichier pageXML lisible dans eScriptorium sous la forme d'une fonction
- Création d'un script pour supprimer les balises `<b>` et `<i>` des fichiers pageXML. 
- Ajout de documentation sphinx pour les deux scripts.