### PR TITLE
Ajout automatique des lignes defaults

### DIFF
--- a/Boite_a_outils/CorrectionPageXMLeScriptorium/README.md
+++ b/Boite_a_outils/CorrectionPageXMLeScriptorium/README.md
@@ -11,7 +11,7 @@ les fichiers xml à modifier, puis le nom du dossier de sortie de cette transfor
 ``depart.xml`` est le fichier duquel par l'exemple de sortie. Celui-ci est issu des <i>Lettres</i> d'Honoré de Balzac publié en 1624. IL est possible de retrouver 
 un exemplaire de ce livre en cliquant sur le lien suivant : https://gallica.bnf.fr/ark:/12148/btv1b86262420/f9.item.
 
-``migrationCorrection.xsl`` est le fichier de transformation xsl. <b>Attention ! Ce document a été réalisé dans le but d'une transformation facilitant une segmentation. Pour cette raison, un attribut par défaut a été ajouté à chaque ligne.</b>
+``migrationCorrection.xsl`` est le fichier de transformation xsl. <b>Attention ! Ce document a été réalisé dans le but d'une transformation facilitant une segmentation dans <i>eScriptorium</i>. Pour cette raison, un attribut par défaut a été ajouté à chaque ligne.</b>
 
 ## Informations sur l'utilisation des fichiers
 Il suffit d'avoir le fichier python et le fichier xsl dans le même dossier poour pouvoir les utiliser sans avoir à changer quoi que ce soit.

--- a/Boite_a_outils/CorrectionPageXMLeScriptorium/README.md
+++ b/Boite_a_outils/CorrectionPageXMLeScriptorium/README.md
@@ -11,7 +11,7 @@ les fichiers xml à modifier, puis le nom du dossier de sortie de cette transfor
 ``depart.xml`` est le fichier duquel par l'exemple de sortie. Celui-ci est issu des <i>Lettres</i> d'Honoré de Balzac publié en 1624. IL est possible de retrouver 
 un exemplaire de ce livre en cliquant sur le lien suivant : https://gallica.bnf.fr/ark:/12148/btv1b86262420/f9.item.
 
-``migrationCorrection.xsl`` est le fichier de transformation xsl.
+``migrationCorrection.xsl`` est le fichier de transformation xsl. <b>Attention ! Ce document a été réalisé dans le but d'une transformation facilitant une segmentation. Pour cette raison, un attribut par défaut a été ajouté à chaque ligne.</b>
 
 ## Informations sur l'utilisation des fichiers
 Il suffit d'avoir le fichier python et le fichier xsl dans le même dossier poour pouvoir les utiliser sans avoir à changer quoi que ce soit.

--- a/Boite_a_outils/CorrectionPageXMLeScriptorium/migrationCorrection.xsl
+++ b/Boite_a_outils/CorrectionPageXMLeScriptorium/migrationCorrection.xsl
@@ -7,8 +7,6 @@
     version="1.0">
     <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
     
-    
-    
     <xsl:template match="pr:PcGts">
         <PcGts xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15/pagecontent.xsd">
             <xsl:copy-of select="pr:Metadata"/>
@@ -60,6 +58,8 @@
                 <xsl:value-of select="@primaryLanguage"/>
             </xsl:attribute>
             <xsl:attribute name="custom">
+                <!--Ajout pour toutes les lignes de la valeur default d'après l'ontologie SegmOnto-->
+                <xsl:text>structure {type:default;} </xsl:text>
                 <xsl:value-of select="@custom"/>
             </xsl:attribute>
             <xsl:copy-of select="pr:Coords"/>


### PR DESCRIPTION
Ajout de l'élément `structure {type:default;}` dans l'attribut custom des TextLine dans la feuille de transformation XSL dans le but d'automatiser le nommage des zones et lignes d'après segmOnto