### PR TITLE
Retrait transcription de fichiers xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Ce dossier contient un script Python ainsi qu'une feuille de transformation xsl 
 
 _Créé par [@Heresta](http://github.com/Heresta) et [@Juliettejns](http://github.com/Juliettejns)_
 
+### Dossier - RetraitTranscriptionPAGEXML
+Ce dossier contient un script Python ainsi qu'une feuille de transformation xsl qui ont pour but de partir d'un fichier xml sortant d'eScriptorium pour en enlever les transcriptions et en faire un simple fichier de segmentation. Cela a pour but d'aider les tests sur les modèles de recognizer d'eScriptorium tant que l'on n'a pas de modèle de segmentation qui fonctionne. [En savoir plus (README)](https://github.com/Heresta/BAO_Stage_DH_ENS_2021/blob/main/RetraitTranscriptionPAGEXML/README.md)
+
+[Lien vers le dossier ``RetraitTranscriptionPAGEXML``](https://github.com/Heresta/BAO_Stage_DH_ENS_2021/tree/main/RetraitTranscriptionPAGEXML)
+
+_Créé par [@Heresta](http://github.com/Heresta)_
+
 ### Dossier - documentationFormatsExistants
 Ce dossier contient quatre fichiers xml commentés en français en fonction de leur documentation, de notre utilisation et de notre compréhension. Ils présentent plusieurs formats : 
 - ALTO

--- a/RetraitTranscriptionPAGEXML/README.md
+++ b/RetraitTranscriptionPAGEXML/README.md
@@ -1,0 +1,1 @@
+# Automatisation du retrait de la transcription des fichiers PAGE-XML sortant d'eScriptorium

--- a/RetraitTranscriptionPAGEXML/README.md
+++ b/RetraitTranscriptionPAGEXML/README.md
@@ -1,1 +1,21 @@
 # Automatisation du retrait de la transcription des fichiers PAGE-XML sortant d'eScriptorium
+Pour information, ces script python et de transformation xslt sont largement basés sur ceux qui se trouvent dans le dossier [CorrectionPageXMLeScriptorium](https://github.com/Heresta/BAO_Stage_DH_ENS_2021/tree/main/CorrectionPageXMLeScriptorium).
+
+## Les fichiers
+Dans ce dossier, vous pourrez trouver 4 fichiers. 
+
+``xml_segment_only.py`` est le fichier python qui sert à l'automatisation de la transformation. Il suffit d'entrer le chemin du dossier d'origine où se trouvent 
+les fichiers xml à modifier, puis le nom du dossier de sortie de cette transformation. 
+
+``arrivee.xml`` est un exemple de fichier de sortie que donne le document de transformation xsl.
+
+``depart.xml`` est le fichier duquel part l'exemple de sortie. Celui-ci est issu des _Caractères_ de Jean de La Bruyère publié en 1688. Il est possible de retrouver 
+un exemplaire de ce livre en cliquant sur le lien suivant : https://gallica.bnf.fr/ark:/12148/btv1b86070385/f14.item.
+
+``retrait_transcription.xsl`` est le fichier de transformation xsl. <b>Attention ! Ce document a été réalisé avec un certain type de namespace. Il faut absolument vérifier que le namespace du document xsl est le même que celui du document PAGE-XML que vous souhaitez traiter. Dans le cas contraire, il suffit de le modifier pour que la transformation fonctionne.</b>
+
+## Informations sur l'utilisation des fichiers
+Il suffit d'avoir le fichier python et le fichier xsl dans le même dossier poour pouvoir les utiliser sans avoir à changer quoi que ce soit.
+
+Attention ! A noter que lors des inputs pour faire tourner l'automatisation, il est nécessaire de finir son chemin par un ``/``, comme par exemple
+``/home/OCR17plus-master/Data/Descartes1637_Discours_btv1b86069594_corrected/page/``.

--- a/RetraitTranscriptionPAGEXML/arrivee.xml
+++ b/RetraitTranscriptionPAGEXML/arrivee.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PcGts xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:pr="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
+       xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd">
+   <Metadata>
+      <Creator>escriptorium</Creator>
+      <Created>2021-04-23T09:14:46.265374+00:00</Created>
+      <LastChange>2021-04-23T09:14:46.265396+00:00</LastChange>
+   </Metadata>
+   <Page imageFilename="Bruyere1688_Caracteres_btv1b86070385_corrected_0016.png"
+         imageWidth="4267"
+         imageHeight="7116">
+      <TextRegion id="r_1_2" custom="structure {type:Main;}">
+         <Coords points="1250,596 3943,586 3933,5861 1221,5861"/>
+         <TextLine id="tl_1" custom="structure {type:Default;}">
+            <Coords points="1298,635 3911,635 3911,928 1298,928"/>
+            <Baseline points="1298,828 1663,829 2547,825 3139,824 3274,793 3527,906 3911,864"/>
+         </TextLine>
+         <TextLine id="tl_2" custom="structure {type:Default;}">
+            <Coords points="1293,891 3882,891 3882,1180 1293,1180"/>
+            <Baseline points="1293,1084 1453,1084 2673,1082 3881,1116"/>
+         </TextLine>
+         <TextLine id="tl_3" custom="structure {type:Default;}">
+            <Coords points="1291,1155 3881,1155 3881,1428 1291,1428"/>
+            <Baseline points="1292,1348 1780,1418 2104,1339 2660,1342 2868,1351 3204,1345 3880,1416"/>
+         </TextLine>
+         <TextLine id="tl_4" custom="structure {type:Default;}">
+            <Coords points="1294,1419 3927,1419 3927,1692 1294,1692"/>
+            <Baseline points="1294,1680 2075,1615 2383,1617 3131,1616 3458,1626 3926,1648"/>
+         </TextLine>
+         <TextLine id="tl_5" custom="structure {type:Default;}">
+            <Coords points="1285,1683 1990,1683 1990,1867 1285,1867"/>
+            <Baseline points="1285,1864 1454,1860 1989,1863"/>
+         </TextLine>
+         <TextLine id="tl_6" custom="structure {type:Default;}">
+            <Coords points="1548,1941 3925,1941 3925,2144 1548,2144"/>
+            <Baseline points="1548,2129 1689,2121 2152,2128 2876,2127 3396,2134 3924,2140"/>
+         </TextLine>
+         <TextLine id="tl_7" custom="structure {type:Default;}">
+            <Coords points="1278,2191 3932,2191 3932,2476 1278,2476"/>
+            <Baseline points="1279,2380 1807,2382 2583,2426 3099,2388 3931,2388"/>
+         </TextLine>
+         <TextLine id="tl_8" custom="structure {type:Default;}">
+            <Coords points="1273,2463 3870,2463 3870,2732 1273,2732"/>
+            <Baseline points="1273,2656 1594,2641 2038,2643 2606,2658 3534,2658 3870,2664"/>
+         </TextLine>
+         <TextLine id="tl_9" custom="structure {type:Default;}">
+            <Coords points="1276,2719 3861,2719 3861,2936 1276,2936"/>
+            <Baseline points="1276,2916 1905,2898 2377,2905 3025,2908 3256,2933 3533,2918 3860,2896"/>
+         </TextLine>
+         <TextLine id="tl_10" custom="structure {type:Default;}">
+            <Coords points="1255,2967 3864,2967 3864,3220 1255,3220"/>
+            <Baseline points="1255,3160 1911,3162 2003,3211 2168,3164 3351,3177 3863,3152"/>
+         </TextLine>
+         <TextLine id="tl_11" custom="structure {type:Default;}">
+            <Coords points="1257,3235 3927,3235 3927,3496 1257,3496"/>
+            <Baseline points="1258,3440 1390,3440 2322,3428 2718,3426 3926,3496"/>
+         </TextLine>
+         <TextLine id="tl_12" custom="structure {type:Default;}">
+            <Coords points="1264,3491 3857,3491 3857,3712 1264,3712"/>
+            <Baseline points="1264,3688 1433,3688 1684,3701 2477,3681 2973,3688 3281,3693 3857,3676"/>
+         </TextLine>
+         <TextLine id="tl_13" custom="structure {type:Default;}">
+            <Coords points="1251,3759 3848,3759 3848,4036 1251,4036"/>
+            <Baseline points="1251,3964 1616,3941 1968,3943 2468,3945 2664,4014 2892,3951 3240,3949 3847,4008"/>
+         </TextLine>
+         <TextLine id="tl_14" custom="structure {type:Default;}">
+            <Coords points="1250,4011 3843,4011 3843,4240 1250,4240"/>
+            <Baseline points="1250,4204 1470,4200 1939,4223 2263,4208 2610,4222 3842,4188"/>
+         </TextLine>
+         <TextLine id="tl_15" custom="structure {type:Default;}">
+            <Coords points="1236,4279 3858,4279 3858,4556 1236,4556"/>
+            <Baseline points="1237,4468 1545,4461 1853,4482 2425,4485 3301,4473 3857,4476"/>
+         </TextLine>
+         <TextLine id="tl_16" custom="structure {type:Default;}">
+            <Coords points="1243,4535 3912,4535 3912,4780 1243,4780"/>
+            <Baseline points="1243,4724 2556,4730 2780,4743 3036,4748 3911,4780"/>
+         </TextLine>
+         <TextLine id="tl_17" custom="structure {type:Default;}">
+            <Coords points="1234,4795 3911,4795 3911,5072 1234,5072"/>
+            <Baseline points="1234,5004 1399,5004 2270,5008 3367,5005 3910,5004"/>
+         </TextLine>
+         <TextLine id="tl_18" custom="structure {type:Default;}">
+            <Coords points="1232,5059 3834,5059 3834,5332 1232,5332"/>
+            <Baseline points="1233,5239 1393,5240 2149,5244 2601,5250 3213,5253 3834,5252"/>
+         </TextLine>
+         <TextLine id="tl_19" custom="structure {type:Default;}">
+            <Coords points="1223,5319 3828,5319 3828,5596 1223,5596"/>
+            <Baseline points="1224,5507 2412,5509 3296,5517 3828,5484"/>
+         </TextLine>
+         <TextLine id="tl_20" custom="structure {type:Default;}">
+            <Coords points="1222,5579 3827,5579 3827,5860 1222,5860"/>
+            <Baseline points="1222,5780 1763,5786 2011,5775 2751,5779 3479,5774 3827,5772"/>
+         </TextLine>
+      </TextRegion>
+      <TextRegion id="eSc_textblock_00f1afda" custom="structure {type:RunningTitle;}">
+         <Coords points="2260,388 2260,602 2962,602 2962,388"/>
+         <TextLine id="eSc_line_43ac8a0b" custom="structure {type:Default;}">
+            <Coords points="2225,551 2237,385 2302,343 2445,385 2599,343 2676,379 2729,349 2765,385 2955,385 2967,557 2884,610 2795,587 2759,616 2700,598 2646,622 2397,628 2356,587 2231,587"/>
+            <Baseline points="2231,553 2971,563"/>
+         </TextLine>
+      </TextRegion>
+   </Page>
+</PcGts>

--- a/RetraitTranscriptionPAGEXML/depart.xml
+++ b/RetraitTranscriptionPAGEXML/depart.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"  standalone="yes"?>
+<PcGts xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd">
+  <Metadata>
+	<Creator>escriptorium</Creator>
+	<Created>2021-04-23T09:14:46.265374+00:00</Created>
+    <LastChange>2021-04-23T09:14:46.265396+00:00</LastChange>
+  </Metadata>
+  <Page imageFilename="Bruyere1688_Caracteres_btv1b86070385_corrected_0016.png" imageWidth="4267" imageHeight="7116">
+
+    
+    <TextRegion id="r_1_2"  custom="structure {type:Main;}">
+      <Coords points="1250,596 3943,586 3933,5861 1221,5861"/>
+      
+      
+      <TextLine id="tl_1" custom="structure {type:Default;}">
+        <Coords points="1298,635 3911,635 3911,928 1298,928"/>
+        <Baseline points="1298,828 1663,829 2547,825 3139,824 3274,793 3527,906 3911,864"/>
+        <TextEquiv>
+          <Unicode>l’on explique celles-cy par</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_2" custom="structure {type:Default;}">
+        <Coords points="1293,891 3882,891 3882,1180 1293,1180"/>
+        <Baseline points="1293,1084 1453,1084 2673,1082 3881,1116"/>
+        <TextEquiv>
+          <Unicode>le mouvement du ſang, par</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_3" custom="structure {type:Default;}">
+        <Coords points="1291,1155 3881,1155 3881,1428 1291,1428"/>
+        <Baseline points="1292,1348 1780,1418 2104,1339 2660,1342 2868,1351 3204,1345 3880,1416"/>
+        <TextEquiv>
+          <Unicode>celuy des fibres &amp; des arteres,</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_4" custom="structure {type:Default;}">
+        <Coords points="1294,1419 3927,1419 3927,1692 1294,1692"/>
+        <Baseline points="1294,1680 2075,1615 2383,1617 3131,1616 3458,1626 3926,1648"/>
+        <TextEquiv>
+          <Unicode>quittent; un Auteur de tout,</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_5" custom="structure {type:Default;}">
+        <Coords points="1285,1683 1990,1683 1990,1867 1285,1867"/>
+        <Baseline points="1285,1864 1454,1860 1989,1863"/>
+        <TextEquiv>
+          <Unicode>le reſte.</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_6" custom="structure {type:Default;}">
+        <Coords points="1548,1941 3925,1941 3925,2144 1548,2144"/>
+        <Baseline points="1548,2129 1689,2121 2152,2128 2876,2127 3396,2134 3924,2140"/>
+        <TextEquiv>
+          <Unicode>Il s’en trouve d’un troi¬</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_7" custom="structure {type:Default;}">
+        <Coords points="1278,2191 3932,2191 3932,2476 1278,2476"/>
+        <Baseline points="1279,2380 1807,2382 2583,2426 3099,2388 3931,2388"/>
+        <TextEquiv>
+          <Unicode>ſiéme ordre, qui perſua¬</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_8" custom="structure {type:Default;}">
+        <Coords points="1273,2463 3870,2463 3870,2732 1273,2732"/>
+        <Baseline points="1273,2656 1594,2641 2038,2643 2606,2658 3534,2658 3870,2664"/>
+        <TextEquiv>
+          <Unicode>dez que toute doctrine des</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_9" custom="structure {type:Default;}">
+        <Coords points="1276,2719 3861,2719 3861,2936 1276,2936"/>
+        <Baseline points="1276,2916 1905,2898 2377,2905 3025,2908 3256,2933 3533,2918 3860,2896"/>
+        <TextEquiv>
+          <Unicode>mœurs doit tendre à les re¬</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_10" custom="structure {type:Default;}">
+        <Coords points="1255,2967 3864,2967 3864,3220 1255,3220"/>
+        <Baseline points="1255,3160 1911,3162 2003,3211 2168,3164 3351,3177 3863,3152"/>
+        <TextEquiv>
+          <Unicode>former, à diſcerner les bon¬</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_11" custom="structure {type:Default;}">
+        <Coords points="1257,3235 3927,3235 3927,3496 1257,3496"/>
+        <Baseline points="1258,3440 1390,3440 2322,3428 2718,3426 3926,3496"/>
+        <TextEquiv>
+          <Unicode>nes d’avec les mauvaiſes,</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_12" custom="structure {type:Default;}">
+        <Coords points="1264,3491 3857,3491 3857,3712 1264,3712"/>
+        <Baseline points="1264,3688 1433,3688 1684,3701 2477,3681 2973,3688 3281,3693 3857,3676"/>
+        <TextEquiv>
+          <Unicode>&amp; à démêler dans les hom¬</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_13" custom="structure {type:Default;}">
+        <Coords points="1251,3759 3848,3759 3848,4036 1251,4036"/>
+        <Baseline points="1251,3964 1616,3941 1968,3943 2468,3945 2664,4014 2892,3951 3240,3949 3847,4008"/>
+        <TextEquiv>
+          <Unicode>mes ce qu’il y a de vain,</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_14" custom="structure {type:Default;}">
+        <Coords points="1250,4011 3843,4011 3843,4240 1250,4240"/>
+        <Baseline points="1250,4204 1470,4200 1939,4223 2263,4208 2610,4222 3842,4188"/>
+        <TextEquiv>
+          <Unicode>de foible &amp; de ridicule, d’a¬</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_15" custom="structure {type:Default;}">
+        <Coords points="1236,4279 3858,4279 3858,4556 1236,4556"/>
+        <Baseline points="1237,4468 1545,4461 1853,4482 2425,4485 3301,4473 3857,4476"/>
+        <TextEquiv>
+          <Unicode>vec ce qu’ils peuvent avoir</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_16" custom="structure {type:Default;}">
+        <Coords points="1243,4535 3912,4535 3912,4780 1243,4780"/>
+        <Baseline points="1243,4724 2556,4730 2780,4743 3036,4748 3911,4780"/>
+        <TextEquiv>
+          <Unicode>de bon, de ſain &amp; de loüable,</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_17" custom="structure {type:Default;}">
+        <Coords points="1234,4795 3911,4795 3911,5072 1234,5072"/>
+        <Baseline points="1234,5004 1399,5004 2270,5008 3367,5005 3910,5004"/>
+        <TextEquiv>
+          <Unicode>ſe plaiſent infiniment dans</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_18" custom="structure {type:Default;}">
+        <Coords points="1232,5059 3834,5059 3834,5332 1232,5332"/>
+        <Baseline points="1233,5239 1393,5240 2149,5244 2601,5250 3213,5253 3834,5252"/>
+        <TextEquiv>
+          <Unicode>la lecture des livres, qui</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_19" custom="structure {type:Default;}">
+        <Coords points="1223,5319 3828,5319 3828,5596 1223,5596"/>
+        <Baseline points="1224,5507 2412,5509 3296,5517 3828,5484"/>
+        <TextEquiv>
+          <Unicode>ſuppoſant les principes phy¬</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+      
+      <TextLine id="tl_20" custom="structure {type:Default;}">
+        <Coords points="1222,5579 3827,5579 3827,5860 1222,5860"/>
+        <Baseline points="1222,5780 1763,5786 2011,5775 2751,5779 3479,5774 3827,5772"/>
+        <TextEquiv>
+          <Unicode>ſiques &amp; moraux rebatus par</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+    </TextRegion>
+    
+    <TextRegion id="eSc_textblock_00f1afda"  custom="structure {type:RunningTitle;}">
+      <Coords points="2260,388 2260,602 2962,602 2962,388"/>
+      
+      
+      <TextLine id="eSc_line_43ac8a0b" custom="structure {type:Default;}">
+        <Coords points="2225,551 2237,385 2302,343 2445,385 2599,343 2676,379 2729,349 2765,385 2955,385 2967,557 2884,610 2795,587 2759,616 2700,598 2646,622 2397,628 2356,587 2231,587"/>
+        <Baseline points="2231,553 2971,563"/>
+        <TextEquiv>
+          <Unicode>Diſcours</Unicode>
+        </TextEquiv>
+      </TextLine>
+
+      
+    </TextRegion>
+    
+
+    
+  </Page>
+</PcGts>

--- a/RetraitTranscriptionPAGEXML/retrait_transcription.xsl
+++ b/RetraitTranscriptionPAGEXML/retrait_transcription.xsl
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:pr="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
+    xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
+    exclude-result-prefixes="xs"
+    version="2.0">
+    
+    <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+    
+    <xsl:template match="pr:PcGts">
+        <PcGts xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd">
+            <xsl:copy-of select="pr:Metadata"/>
+            <xsl:apply-templates select="pr:Page"/>
+        </PcGts>
+    </xsl:template>
+    
+    <xsl:template match="pr:Page">
+        <xsl:element name="Page">
+            <xsl:attribute name="imageFilename">
+                <xsl:value-of select="@imageFilename"/>
+            </xsl:attribute>
+            <xsl:attribute name="imageWidth">
+                <xsl:value-of select="@imageWidth"/>
+            </xsl:attribute>
+            <xsl:attribute name="imageHeight">
+                <xsl:value-of select="@imageHeight"/>
+            </xsl:attribute>
+            <xsl:apply-templates select="pr:TextRegion"/>
+        </xsl:element>
+    </xsl:template>
+    
+    <xsl:template match="pr:TextRegion">
+        <xsl:element name="TextRegion">
+            <xsl:attribute name="id">
+                <xsl:value-of select="@id"/>
+            </xsl:attribute>
+            <xsl:attribute name="custom">
+                <xsl:value-of select="@custom"/>
+            </xsl:attribute>
+            <xsl:copy-of select="pr:Coords"/>
+            <xsl:apply-templates select="pr:TextLine"/>
+        </xsl:element>
+    </xsl:template>
+    
+    <xsl:template match="pr:TextLine">
+        <xsl:element name="TextLine">
+            <xsl:attribute name="id">
+                <xsl:value-of select="@id"/>
+            </xsl:attribute>
+            <xsl:attribute name="custom">
+                <xsl:value-of select="@custom"/>
+            </xsl:attribute>
+            <xsl:copy-of select="pr:Coords"/>
+            <xsl:copy-of select="pr:Baseline"/></xsl:element>
+    </xsl:template>
+</xsl:stylesheet>

--- a/RetraitTranscriptionPAGEXML/xml_segment_only.py
+++ b/RetraitTranscriptionPAGEXML/xml_segment_only.py
@@ -1,0 +1,39 @@
+#import des librairies nécessaires
+import os
+from lxml import etree as ET
+import errno
+
+def transformation_automatique(chemin, dossier_resultat):
+    """
+    Fonction permettant, pour chaque fichier d'un dossier donné, de lui appliquer la feuille de transformation
+    retrait_transcription.xsl qui récupère tout ce qui se trouve dans le fichier PAGE-XML qui sort d'eScriptorium
+    sauf la transcription dans le but d'entraîner plus aisément un modèle de transcription sans avoir de modèle de 
+    segmentation qui fonctione parfaitement.
+    :param chemin: chaîne de caractères correspondant au chemin relatif du dossier contenant les fichiers à transformer
+    :type chemin: str
+    :param dossier_resultat:chaîne de caractères correspondant au chemin relatif du dossier devant contenir l'output
+    :type dossier_resultat: str
+    :return: fichier pageXML contenant une version corrigée de l'input
+    :return: file
+    """
+    # si le dossier résultat n'existe pas, on le créé, sinon, on ne fait rien
+    if not os.path.exists(os.path.dirname(dossier_resultat)):
+        try:
+            os.makedirs(os.path.dirname(dossier_resultat))
+        except OSError as exc:  # Guard against race condition
+            if exc.errno != errno.EEXIST:
+                raise
+
+    for fichier in os.listdir(chemin):
+        # pour chaque fichier du dossier, on applique la feuille de transformation de correction
+        original = ET.parse(chemin+fichier)
+        transformation_xlst = ET.XSLT(ET.parse("retrait_transcription.xsl"))
+        propre = transformation_xlst(original)
+        #on créé un nouveau fichier dans le dossier résultat
+        with open(dossier_resultat+fichier, mode='wb') as f:
+            f.write(propre)
+
+# récupérer le dossier à transformer et le dossier résultat
+chemin_input = input("entrez le chemin du dossier: ")
+chemin_output = input("entrez le chemin du dossier résultat: ")
+transformation_automatique(chemin_input, chemin_output)


### PR DESCRIPTION
Il s'agit d'une request pour ajouter un nouveau dossier qui donne la possibilité de partir d'un fichier xml sortant d'eScriptorium pour en enlever les transcriptions et en faire un simple fichier de segmentation. Cela a pour but d'aider les tests sur les modèles de recognizer d'eScriptorium tant que l'on n'a pas de modèle de segmentation qui fonctionne.